### PR TITLE
Change module path from monitoring-forge to kazeburo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/monitoring-forge/ltsvparser
+module github.com/kazeburo/ltsvparser
 
 go 1.25
 


### PR DESCRIPTION
This pull request put back the Go module path in the `go.mod` file to reflect a new repository location.

- Module path changed from `github.com/monitoring-forge/ltsvparser` to `github.com/kazeburo/ltsvparser` in `go.mod`